### PR TITLE
refactor: move and rename layout components

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,25 +1,18 @@
 <template>
-  <div class="app">
-    <Header />
-    <main class="app__main">
-      <!-- This renders the current route component -->
-      <RouterView />
-    </main>
-    <Footer />
-  </div>
+  <DefaultLayout>
+    <RouterView />
+  </DefaultLayout>
 </template>
 
 <script lang="ts">
 import { RouterView } from "vue-router";
-import Header from "./components/Header.vue";
-import Footer from "./components/Footer.vue";
+import DefaultLayout from "./layouts/DefaultLayout.vue";
 
 export default {
   name: "App",
   components: {
     RouterView,
-    Header,
-    Footer,
+    DefaultLayout,
   },
 };
 </script>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -82,7 +82,7 @@
 import { Icon } from "@iconify/vue";
 
 export default {
-  name: "FooterComponent",
+  name: "AppFooter",
   components: {
     Icon,
   },

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -44,7 +44,7 @@
 import { Icon } from "@iconify/vue";
 
 export default {
-  name: "HeaderComponent",
+  name: "AppHeader",
   // This is a required step when you want to use any custom components or third-party components within your component's template.
   components: {
     Icon,

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <Header />
+    <main>
+      <slot />
+    </main>
+    <Footer />
+  </div>
+</template>
+
+<script lang="ts">
+import Header from "../components/AppHeader.vue";
+import Footer from "../components/AppFooter.vue";
+
+export default {
+  name: "DefaultLayout",
+  components: { Header, Footer },
+};
+</script>
+
+<style scoped>
+main {
+  min-height: 60vh;
+}
+</style>


### PR DESCRIPTION
### Summary
- In `/components`: changed `Heder.vue` and `Footer.vue` names to `AppHeader.vue` and `AppFooter.vue`
- in `/layouts`: created `DefaultLayout.vue` with the `AppHeader.vue` and `AppFooter.vue`
- used `DefaultLayout.vue` inside `App.vue`