### PR TITLE
fix: remove deprecated .native modifier from click handler

### DIFF
--- a/src/pages/Products.vue
+++ b/src/pages/Products.vue
@@ -22,7 +22,7 @@
         :key="product.id"
         :product="product"
         @add-to-cart="addToCart"
-        @click.native="goToProduct(product.id)"
+        @click="goToProduct(product.id)"
       />
     </div>
   </div>


### PR DESCRIPTION
### Summary

- Replaced `@click.native` with `@click` in `Products.vue`
- Vue 3 no longer requires `.native` modifier on custom components