### PR TITLE
refactor: move interfaces to types folder and update imports

### DIFF
--- a/src/pages/Cart.vue
+++ b/src/pages/Cart.vue
@@ -56,7 +56,7 @@
 import { defineComponent } from "vue";
 import { useCartStore } from "../store/cart";
 import { storeToRefs } from "pinia";
-import type { CartItem } from "../store/cart";
+import type { CartItem } from "../types";
 
 export default defineComponent({
   name: "CartPage",

--- a/src/pages/ProductDetails.vue
+++ b/src/pages/ProductDetails.vue
@@ -34,7 +34,7 @@
 // Import the products store to fetch product data
 import { useProductsStore } from "../store/products";
 // Import the Product type for type safety
-import type { Product } from "../store/cart";
+import type { Product } from "../types";
 
 export default {
   name: "ProductDetailsPage", // Name of the page component

--- a/src/pages/Products.vue
+++ b/src/pages/Products.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import type { Product } from "../store/cart"; // Import the Product type for type safety
+import type { Product } from "../types"; // Import the Product type for type safety
 // Import Vue's defineComponent helper
 import { defineComponent } from "vue";
 // Import the cart store for add-to-cart functionality

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -1,30 +1,6 @@
 // Import the defineStore function from Pinia to create a store
 import { defineStore } from "pinia";
-
-// Define the Product interface to strongly type product objects in the cart,
-//  we chose to use an interface over a type alias for better extensibility
-export interface Product {
-  id: number; // Unique identifier for the product
-  title: string; // Product name/title
-  price: number; // Product price
-  description: string; // Product description
-  category: string; // Product category (e.g., men's clothing)
-  image: string; // URL to the product image
-  rating: {
-    rate: number; // Average rating value
-    count: number; // Number of ratings
-  };
-}
-
-// Define the CartItem interface to represent an item in the cart
-// This is a composition approach, it keeps the Product separate from the cart logic.
-// That violates the Single Responsibility Principle (SRP)
-//extends Product flattens the object and says: “CartItem is literally just a Product + 1 field.”
-// { product: Product } wraps the Product and says: “CartItem is a separate thing that has a product inside it.”
-export interface CartItem {
-  product: Product; // The product object
-  quantity: number; // How many of this product are in the cart
-}
+import type { Product, CartItem } from "../types"; // Import types for strong typing
 
 // Create a Pinia store for managing the shopping cart
 export const useCartStore = defineStore("cart", {

--- a/src/store/products.ts
+++ b/src/store/products.ts
@@ -1,7 +1,7 @@
 // Import defineStore from Pinia to create a store
 import { defineStore } from "pinia";
 // Import the Product type for strong typing
-import type { Product } from "./cart";
+import type { Product } from "../types";
 
 // Create a Pinia store for products
 export const useProductsStore = defineStore("products", {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,24 @@
+// Define the Product interface to strongly type product objects in the cart,
+//  we chose to use an interface over a type alias for better extensibility
+export interface Product {
+  id: number; // Unique identifier for the product
+  title: string; // Product name/title
+  price: number; // Product price
+  description: string; // Product description
+  category: string; // Product category (e.g., men's clothing)
+  image: string; // URL to the product image
+  rating: {
+    rate: number; // Average rating value
+    count: number; // Number of ratings
+  };
+}
+
+// Define the CartItem interface to represent an item in the cart
+// This is a composition approach, it keeps the Product separate from the cart logic.
+// That violates the Single Responsibility Principle (SRP)
+//extends Product flattens the object and says: “CartItem is literally just a Product + 1 field.”
+// { product: Product } wraps the Product and says: “CartItem is a separate thing that has a product inside it.”
+export interface CartItem {
+  product: Product; // The product object
+  quantity: number; // How many of this product are in the cart
+}


### PR DESCRIPTION
### Summary
- Moved `Product` and `CartItem` interfaces to the `types/` folder.
- Updated all relevant imports in the project.
- This improves code organization and maintainability.
